### PR TITLE
Update max Zotero version to 9.*

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
-      "strict_max_version": "8.*"
+      "strict_max_version": "9.*"
     }
   }
 }


### PR DESCRIPTION
Simple change to `manifest.json` to allow this plugin to be installed in Zotero 9. Closes #5.
